### PR TITLE
Upgrade to Stylelint v15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.1.1
+=====
+
+* (improvement) Upgrade to stylelint v15 and fix deprecated rules.
+
+
 1.1.0
 =====
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@21torr/ci-npm",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Base configuration files for CI tools installed via npm",
 	"license": "MIT",
 	"homepage": "https://github.com/21TORR/ci-npm",
@@ -13,10 +13,11 @@
 		"publish-branch": "1.x"
 	},
 	"dependencies": {
-		"@typescript-eslint/eslint-plugin": "^5.17.0",
-		"@typescript-eslint/parser": "^5.17.0",
-		"eslint-plugin-jsdoc": "^38.1.4",
-		"eslint-plugin-react": "^7.29.4",
-		"eslint-plugin-react-hooks": "^4.4.0"
+		"@typescript-eslint/eslint-plugin": "^5.55.0",
+		"@typescript-eslint/parser": "^5.55.0",
+		"eslint-plugin-jsdoc": "^38.1.6",
+		"eslint-plugin-react": "^7.32.2",
+		"eslint-plugin-react-hooks": "^4.6.0",
+		"stylelint-config-standard": "^31.0.0"
 	}
 }

--- a/stylelint/.stylelintrc.yml
+++ b/stylelint/.stylelintrc.yml
@@ -1,7 +1,9 @@
+extends:
+    - "stylelint-config-standard"
+
 # See http://stylelint.io/user-guide/rules/
 rules:
     # Color
-    color-hex-case: lower
     color-hex-length: short
     color-named: never
     color-no-invalid-hex: true
@@ -14,19 +16,9 @@ rules:
 
     # Function
     function-calc-no-unspaced-operator: true
-    function-comma-newline-after: always-multi-line
-    function-comma-newline-before: never-multi-line
-    function-comma-space-after: always-single-line
-    function-comma-space-before: never
     function-linear-gradient-no-nonstandard-direction: true
-    function-max-empty-lines: 0
     function-name-case: lower
     function-url-quotes: always
-    function-whitespace-after: always
-
-    # Number
-    number-leading-zero: never
-    number-no-trailing-zeros: true
 
     # String
     string-no-newline: true
@@ -38,22 +30,16 @@ rules:
 
     # Unit
     unit-disallowed-list: ["pc", "in", "cm", "mm", "ex"]
-    unit-case: lower
     unit-no-unknown: true
 
     # Value
     value-keyword-case: lower
     value-no-vendor-prefix: true
 
-    # Value list
-    value-list-comma-space-after: always-single-line
-    value-list-comma-space-before: never
-
     # Shorthand property
     shorthand-property-no-redundant-values: true
 
     # Property
-    property-case: lower
     property-no-unknown: true
     property-no-vendor-prefix: true
 
@@ -61,40 +47,22 @@ rules:
     keyframe-declaration-no-important: true
 
     # Declaration
-    declaration-bang-space-after: never
-    declaration-bang-space-before: always
-    declaration-colon-space-after: always-single-line
-    declaration-colon-space-before: never
     declaration-no-important: true
 
     # Declaration block
     declaration-block-no-duplicate-properties: true
     declaration-block-no-shorthand-property-overrides: true
-    declaration-block-semicolon-newline-after: always-multi-line
-    declaration-block-semicolon-space-after: always-single-line
-    declaration-block-semicolon-space-before: never
     declaration-block-single-line-max-declarations: 3
-    declaration-block-trailing-semicolon: always
+    declaration-property-value-no-unknown: true
 
     # Block
-    block-closing-brace-newline-after: always
-    block-closing-brace-newline-before: always-multi-line
-    block-closing-brace-space-before: always-single-line
     block-no-empty: true
-    block-opening-brace-newline-after: always-multi-line
-    block-opening-brace-space-after: always-single-line
-    block-opening-brace-space-before: always
 
     # Selector
-    selector-combinator-space-after: always
-    selector-combinator-space-before: always
     selector-max-id: 0
-    selector-pseudo-class-case: lower
-    selector-pseudo-element-case: lower
     selector-pseudo-element-colon-notation: double
     selector-pseudo-element-no-unknown: true
     selector-type-case: lower
-    selector-max-empty-lines: 0
     selector-max-type:
         - 0
         -   ignoreTypes:
@@ -117,11 +85,6 @@ rules:
                 - th
                 - tr
 
-    # Selector list
-    selector-list-comma-newline-after: always
-    selector-list-comma-newline-before: never-multi-line
-    selector-list-comma-space-before: never
-
     # Rule
     rule-empty-line-before:
         - always-multi-line
@@ -131,31 +94,10 @@ rules:
             ignore:
                 - "after-comment"
 
-    # Media feature
-    media-feature-colon-space-after: always
-    media-feature-colon-space-before: never
-    media-feature-range-operator-space-after: always
-    media-feature-range-operator-space-before: always
-
-    # Media query list
-    media-query-list-comma-space-after: always-single-line
-    media-query-list-comma-space-before: never
-
-    # At rule
-    at-rule-name-case: lower
-    at-rule-name-space-after: always-single-line
-    at-rule-semicolon-newline-after: always
-
     # Comments
     comment-no-empty: true
 
     # General / Sheet
-    indentation: tab
-    max-empty-lines: 2
     max-nesting-depth: 4
     no-duplicate-selectors: true
-    no-eol-whitespace: true
-    no-extra-semicolons: true
-    no-missing-end-of-source-newline: true
     no-unknown-animations: true
-    unicode-bom: never


### PR DESCRIPTION
This change:

- requires at least Stylelint v15
- removes all deprecated rules (see https://stylelint.io/migration-guide/to-15#deprecated-stylistic-rules)
- enables the new rule `declaration-property-value-no-unknown: true` (see https://stylelint.io/migration-guide/to-15#added-declaration-property-value-no-unknown-rule)

This prevents stylelint from screaming at us whenever we're doing a `pnpm update` in any of our projects related to the deprecated rules. However, as Stylelint itself writes in their migration guide: The rules were still working fine, they'll just be removed in v16.

I decided to remove all deprecated rules alltogether since the error output looks like this before the actual stylelint-related issues are actually listed, which is significantly way more noise than I prefer:

![CleanShot 2023-03-20 at 15 10 55](https://user-images.githubusercontent.com/439899/226366280-f40175f3-b5dd-40d0-ba9a-e064bdf2af53.png)

WDYT @apfelbox @21christiansc 